### PR TITLE
fix the slack link

### DIFF
--- a/themes/clean-landing/layouts/partials/community.html
+++ b/themes/clean-landing/layouts/partials/community.html
@@ -17,7 +17,7 @@
               </span>
             </a>
             <h4>Slack</h4>
-            <p><a href="https://slack.cncf.io/">Join the Kubernetes Slack</a> for <a href="https://kubernetes.slack.com/messages/krustlet">#krustlet</a> related discussions.</p>
+            <p><a href="https://slack.k8s.io/">Join the Kubernetes Slack</a> for <a href="https://kubernetes.slack.com/messages/krustlet">#krustlet</a> related discussions.</p>
           </article>
         </div>
         


### PR DESCRIPTION
Addresses issue #12 - the slack.io signup link was pointing to the CNCF team instead of the Kubernetes one.

Thanks for spotting @jetzlstorfer